### PR TITLE
fix: update jenkinsfile to have prod domain and proper location path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,11 @@
 
 hugo (
   appName: 'threadx-rtos-docs',
+  productionDomain: 'threadx.io',
   build: [
     containerImage: 'eclipsefdn/hugo-node:h0.110.0-n18.13.0',
   ],
   deployment: [
-    locationPath: '/threadx/docs'
+    locationPath: '/docs'
   ]
 )


### PR DESCRIPTION
There was a bad value in the path of the initial Jenkinsfile that would have likely made the assets not properly available once built, so a small update was done. Additionally added the actual production domain as I can just disable the main build until we are ready.